### PR TITLE
Added support to run post install/upgrade & reset scripts.

### DIFF
--- a/default.config.sh
+++ b/default.config.sh
@@ -33,6 +33,7 @@ MYSQL_HOSTNAME=""
 MYSQL_DB_NAME=""
 
 
+
 ##
 # External folders or files that need to be symlinked into the www folder
 # AFTER the make files have been processed.
@@ -45,3 +46,31 @@ MYSQL_DB_NAME=""
 ##
 #SYMLINKS[0]="/var/www/library/foldername>sites/all/library/foldername"
 #SYMLINKS[1]="/var/www/shared/filename.php>sites/all/modules/filename.php"
+
+
+
+##
+# Post script functions.
+#
+# These functions are called when the corresponding script has finshed and
+# before the final check of the platform (and optional auto login).
+#
+# Add commands that need to be run per script.
+# The colors, as defined in the scripts/helper-colors.sh file, can be used to
+# highlight echoed text.
+#
+# Following variables can be used (created depending on the script arguments):
+# - $DEMO_CONTENT (0/1) : Should the demo content be loaded into the platform.
+# - $AUTO_LOGIN (0/1)   : Will the script open a browser window and log in as an
+#                         administrator.
+# - $UNATTENDED (0/1)   : Is the script run unattended.
+##
+
+# Post install script.
+# function post_install {}
+
+# Post upgrade script.
+# function post_upgrade {}
+
+# Post reset script.
+# function post_reset {}

--- a/install
+++ b/install
@@ -146,6 +146,9 @@ if [ $DEMO_CONTENT ]; then
   migrate_dummy_content
 fi
 
+# Run post script (if any).
+run_post_script "install"
+
 
 # Check if we have a working bootstrap.
 cd $ROOT/www
@@ -156,7 +159,7 @@ if [ ! "$BOOTSTRAP_SUCCESS" ]; then
   echo
   echo -e  "${BGRED}                                                                 ${RESTORE}"
   echo -e "${BGLRED}  Installation failure!                                          ${RESTORE}"
-  echo -e  "${BGRED}  > Drupal Bootstrap could not complete successfully             ${RESTORE}"
+  echo -e  "${BGRED}  > Drupal Bootstrap could not complete successfully.            ${RESTORE}"
   echo -e  "${BGRED}                                                                 ${RESTORE}"
   echo
   exit 1

--- a/scripts/helper-functions.sh
+++ b/scripts/helper-functions.sh
@@ -281,3 +281,29 @@ function symlink_externals {
   done
   echo
 }
+
+##
+# Check if there is a post script and run it.
+#
+# @param string $1
+#   The kind of post script to run.
+##
+function run_post_script {
+  if [ ! "$1" ]; then
+    return 1
+  fi
+
+  # Define post script name.
+  POST_FUNCT_NAME="post_$1"
+
+  # Check if the function is declared.
+  declare -Ff "$POST_FUNCT_NAME" >/dev/null;
+  if [ $? -eq 1 ]; then
+    return 1
+  fi
+
+  # Run the post script.
+  echo -e "${LBLUE}> Run $POST_FUNCT_NAME script.${RESTORE}"
+  $POST_FUNCT_NAME
+  echo
+}

--- a/scripts/reset
+++ b/scripts/reset
@@ -150,6 +150,9 @@ if [ $DEMO_CONTENT ]; then
   migrate_dummy_content
 fi
 
+# Run post script (if any).
+run_post_script "reset"
+
 
 # Check if we have a working bootstrap.
 cd $ROOT/www
@@ -160,7 +163,7 @@ if [ ! "$BOOTSTRAP_SUCCESS" ]; then
   echo
   echo -e  "${BGRED}                                                                 ${RESTORE}"
   echo -e "${BGLRED}  Reset failure!                                                 ${RESTORE}"
-  echo -e  "${BGRED}  > Drupal Bootstrap could not complete successfully             ${RESTORE}"
+  echo -e  "${BGRED}  > Drupal Bootstrap could not complete successfully.            ${RESTORE}"
   echo -e  "${BGRED}                                                                 ${RESTORE}"
   echo
   exit 1

--- a/upgrade
+++ b/upgrade
@@ -151,6 +151,9 @@ if [ $DEMO_CONTENT ]; then
   migrate_dummy_content
 fi
 
+# Run post script (if any).
+run_post_script "upgrade"
+
 
 # Check if we have a working bootstrap.
 cd $ROOT/www
@@ -161,7 +164,7 @@ if [ ! "$BOOTSTRAP_SUCCESS" ]; then
   echo
   echo -e  "${BGRED}                                                                 ${RESTORE}"
   echo -e "${BGLRED}  Upgrade failure!                                               ${RESTORE}"
-  echo -e  "${BGRED}  > Drupal Bootstrap could not complete successfully             ${RESTORE}"
+  echo -e  "${BGRED}  > Drupal Bootstrap could not complete successfully.            ${RESTORE}"
   echo -e  "${BGRED}                                                                 ${RESTORE}"
   echo
   exit 1


### PR DESCRIPTION
You can add extra commands to run AFTER the Drupal installation/upgrade or reset has finsihed (and before optional login) by adding 3 functions to the config.sh file:
- function post_install {}
- function post_upgrade {}
- function post_reset {}
