### PR TITLE
Replace admin_menu by core toolbar.

### DIFF
--- a/capacity4more/capacity4more.info
+++ b/capacity4more/capacity4more.info
@@ -1,6 +1,5 @@
-; $Id: standard.info,v 1.2 2010/10/25 15:48:41 webchick Exp $
 name = capacity4more
-description = Capacity4More platform installation profile
+description = capacity4more platform installation profile
 version = 1.x-dev
 core = 7.x
 
@@ -22,11 +21,11 @@ dependencies[] = taxonomy
 dependencies[] = dblog
 dependencies[] = search
 dependencies[] = shortcut
+dependencies[] = toolbar
 dependencies[] = file
 dependencies[] = rdf
 
 ; Contrib modules -------------------------------------------------------------
-dependencies[] = admin_menu_toolbar
 dependencies[] = admin_views
 dependencies[] = context
 dependencies[] = ctools

--- a/capacity4more/drupal-org.make
+++ b/capacity4more/drupal-org.make
@@ -2,9 +2,6 @@ core = 7.x
 api = 2
 
 ; Modules
-projects[admin_menu][subdir] = "contrib"
-projects[admin_menu][version] = "3.0-rc4"
-
 projects[admin_views][subdir] = "contrib"
 projects[admin_views][version] = "1.2"
 


### PR DESCRIPTION
admin_menu was causing time-outs (after cache-clear) and slow loading pages, when a lot of content is on the platform.
