### PR TITLE
When adding new minisite pages without a specific parent, the master pag...

### DIFF
--- a/capacity4more/modules/c4m/content/c4m_content_minisite/c4m_content_minisite.module
+++ b/capacity4more/modules/c4m/content/c4m_content_minisite/c4m_content_minisite.module
@@ -98,6 +98,7 @@ function c4m_content_minisite_get_book_by_gid($gid) {
   $q->join('og_membership', 'group_rel', 'node.nid = group_rel.etid');
   $q->fields('node', array('nid'))
     ->condition('group_rel.gid', $gid, '=')
+    ->condition('group_rel.entity_type', 'node', '=')
     ->condition('node.type', 'minisite', '=')
     ->range(0, 1);
   $res = $q->execute()->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
...e from the group is retrieved. There was no filter on entity_type however, causing users who were member of the specific group, that have a user id which matches the node id of a minisite to appear in the result list, of which the first result was picked. Therefore, group pages could have the wrong parent node, just because its node id matches the user id of a member of the group.
