### PR TITLE
SecurityFix : SA-CORE-2014-006

### DIFF
--- a/capacity4more/drupal-org-core.make
+++ b/capacity4more/drupal-org-core.make
@@ -1,7 +1,7 @@
 core = 7.x
 api = 2
 
-projects[drupal][version] = "7.32"
+projects[drupal][version] = "7.34"
 
 
 ; Patch to make it possible to run tests on modules located in a custom profile.


### PR DESCRIPTION
Update Drupal core to 7.34 due to Security Fix for SA-CORE-2014-006
