### PR TITLE
Separate the AngularJs App controllers.

### DIFF
--- a/capacity4more/modules/c4m/message/c4m_message/plugins/content_types/activity_stream/activity-stream.tpl.php
+++ b/capacity4more/modules/c4m/message/c4m_message/plugins/content_types/activity_stream/activity-stream.tpl.php
@@ -1,4 +1,4 @@
-<div class="activity-stream">
+<div class="activity-stream" ng-controller="ActivityCtrl">
   <!-- Display an error if we can't update the activity stream-->
   <div ng-show="stream.status > 0 && stream.status != 200" class="messages">
     <div class="alert alert-danger">

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/activity.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/activity.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('c4mApp')
-  .controller('ActivityCtrl', function($scope, DrupalSettings, GoogleMap, EntityResource, Request, $window, $document, $modal, QuickPostService, $interval, $sce, FileUpload) {
+  .controller('ActivityCtrl', function($scope, DrupalSettings, EntityResource, $interval, $sce) {
 
     // Get the current group ID.
     $scope.group = DrupalSettings.getData('entity').group;
@@ -113,5 +113,11 @@ angular.module('c4mApp')
     $scope.$on('c4m.activity.update', function() {
       // Load new activity.
       $scope.addNewActivities('existingActivities');
+    });
+
+    // Listening to broadcast for changes in the refresh.
+    $scope.$on('c4m.activity.refresh', function(action) {
+      console.log(action);
+      $interval.cancel($scope.refreshing);
     });
   });

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/activity.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/activity.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('c4mApp')
-  .controller('ActivityCtrl', function($scope, DrupalSettings, EntityResource, $interval, $sce) {
+  .controller('ActivityCtrl', function($scope, DrupalSettings, EntityResource, $timeout, $interval, $sce) {
 
     // Get the current group ID.
     $scope.group = DrupalSettings.getData('entity').group;
@@ -116,8 +116,17 @@ angular.module('c4mApp')
     });
 
     // Listening to broadcast for changes in the refresh.
-    $scope.$on('c4m.activity.refresh', function(action) {
-      console.log(action);
-      $interval.cancel($scope.refreshing);
+    // This will stop or resume the refresh of the activity stream.
+    // In case of resuming the activity stream,
+    // Wait for 10 seconds to avoid any conflicts between the normal refresh and the "create new activity" pull.
+    $scope.$on('c4m.activity.refresh', function(broadcast, action) {
+      if(action == 'stop') {
+        $interval.cancel($scope.refreshing);
+      }
+      else {
+        $timeout(function() {
+          $scope.refreshing = $interval($scope.refresh, $scope.refreshRate);
+        }, 10000);
+      }
     });
   });

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/activity.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/activity.js
@@ -1,0 +1,117 @@
+'use strict';
+
+angular.module('c4mApp')
+  .controller('ActivityCtrl', function($scope, DrupalSettings, GoogleMap, EntityResource, Request, $window, $document, $modal, QuickPostService, $interval, $sce, FileUpload) {
+
+    // Get the current group ID.
+    $scope.group = DrupalSettings.getData('entity').group;
+
+    // Getting the activity stream.
+    $scope.existingActivities = DrupalSettings.getActivities();
+
+    // Empty new activities.
+    $scope.newActivities = [];
+
+    // Activity stream status, refresh time.
+    $scope.stream = {
+      // The first one is the last loaded activity, (if no activities, insert 0).
+      lastLoadedID: $scope.existingActivities.length > 0 ? $scope.existingActivities[0].id : 0,
+      status: 0
+    };
+
+    // refresh rate of the activity stream (60000 is one minute).
+    // @TODO: Import the refresh rate from the drupal settings.
+    $scope.refreshRate = 60000;
+
+    /**
+     * Refreshes the activity stream.
+     * The refresh rate is scope.refreshRate.
+     */
+    $scope.refresh = function() {
+      $scope.addNewActivities('newActivities');
+    };
+    // Start the activity stream refresh.
+    $scope.refreshing = $interval($scope.refresh, $scope.refreshRate);
+
+    /**
+     * Adds newly fetched activities to either to the activity-stream or the load button,
+     * Depending on if the current user added an activity or it's fetched from the server.
+     *
+     * @param type
+     *  Determines to which variable the new activity should be added,
+     *  existingActivities: The new activity will be added straight to the activity stream. (Highlighted as well)
+     *  newActivities: The "new posts" notification button will appear in the user's activity stream.
+     */
+    $scope.addNewActivities = function(type) {
+      if (type == 'existingActivities') {
+        // Merge all the loaded activities before adding the created one.
+        $scope.showNewActivities();
+      }
+
+      var activityStreamInfo = {
+        group: $scope.group,
+        lastId: $scope.stream.lastLoadedID
+      };
+
+      // Don't send a request when data is missing.
+      if(!activityStreamInfo.lastId || !activityStreamInfo.group) {
+        // If last ID is 0, this is a new group and there's no activities.
+        if(activityStreamInfo.lastId != 0) {
+          $scope.stream.status = 500;
+          return false;
+        }
+      }
+
+      // Call the update stream method.
+      EntityResource.updateStream(activityStreamInfo)
+        .success( function (data, status) {
+          // Update the stream status.
+          $scope.stream.status = status;
+
+          // Update if there's new activities.
+          if (data.data) {
+            // Count the activities that were fetched.
+            var position = 0;
+            angular.forEach(data.data, function (activity) {
+              this.splice(position, 0, {
+                id: activity.id,
+                html: $sce.trustAsHtml(activity.html)
+              });
+              position++;
+            }, $scope[type]);
+
+            // Update the last loaded ID.
+            // Only if there's new activities from the server.
+            $scope.stream.lastLoadedID = $scope[type][0].id ? $scope[type][0].id : $scope.stream.lastLoadedID;
+          }
+        })
+        .error( function (data, status) {
+          // Update the stream status if we get an error, This will display the error message.
+          $scope.stream.status = status;
+        });
+    };
+
+    /**
+     * Merge the "new activity" with the existing activity stream.
+     * When a user has clicked on the "new posts", we grab the activities in the "new activity" group and push them to the top of the "existing activity", and clear the "new activity" group.
+     */
+    $scope.showNewActivities = function() {
+      var position = 0;
+      angular.forEach ($scope.newActivities, function (activity) {
+        this.splice(position, 0, {
+          id: activity.id,
+          created: activity.created,
+          html: activity.html
+        });
+        position++;
+      }, $scope.existingActivities);
+      $scope.newActivities = [];
+    };
+
+    // Listening to broadcast for changes in the activity.
+    // e.g. Adding a new activity from the "main" controller.
+    $scope.$on('c4m.activity.update', function() {
+      // Load new activity.
+      $scope.addNewActivities('existingActivities');
+    });
+  });

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('c4mApp')
-  .controller('MainCtrl', function($rootScope, $scope, DrupalSettings, GoogleMap, EntityResource, Request, $window, $document, $modal, QuickPostService, $interval, $sce, FileUpload) {
+  .controller('MainCtrl', function($rootScope, $scope, DrupalSettings, GoogleMap, EntityResource, Request, $window, $document, $modal, QuickPostService, FileUpload) {
 
     $scope.data = DrupalSettings.getData('entity');
 

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
@@ -188,7 +188,7 @@ angular.module('c4mApp')
 
       // Stop the "Activity-stream" auto refresh When submitting a new activity,
       // because we don't want the auto refresh to display the activity as an old one.
-      $interval.cancel($scope.refreshing);
+      $rootScope.$broadcast('c4m.activity.refresh', 'stop');
 
       // Reset all errors.
       $scope.errors = {};

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
@@ -286,7 +286,7 @@ angular.module('c4mApp')
       $scope.resetEntityForm();
 
       // Resume the "Activity-stream" auto refresh.
-      $scope.refreshing = $interval($scope.refresh, $scope.refreshRate);
+      $rootScope.$broadcast('c4m.activity.refresh', 'continue');
     };
 
     /**

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('c4mApp')
-  .controller('MainCtrl', function($scope, DrupalSettings, GoogleMap, EntityResource, Request, $window, $document, $modal, QuickPostService, $interval, $sce, FileUpload) {
+  .controller('MainCtrl', function($rootScope, $scope, DrupalSettings, GoogleMap, EntityResource, Request, $window, $document, $modal, QuickPostService, $interval, $sce, FileUpload) {
 
     $scope.data = DrupalSettings.getData('entity');
 
@@ -34,109 +34,7 @@ angular.module('c4mApp')
 
     $scope = QuickPostService.setDefaults($scope);
 
-    // Getting the activity stream.
-    $scope.existingActivities = DrupalSettings.getActivities();
-
     $scope.basePath = DrupalSettings.getBasePath();
-
-    // Empty new activities.
-    $scope.newActivities = [];
-
-    // Activity stream status, refresh time.
-    $scope.stream = {
-      // The first one is the last loaded activity, (if no activities, insert 0).
-      lastLoadedID: $scope.existingActivities.length > 0 ? $scope.existingActivities[0].id : 0,
-      status: 0
-    };
-
-    // refresh rate of the activity stream (60000 is one minute).
-    // @TODO: Import the refresh rate from the drupal settings.
-    $scope.refreshRate = 60000;
-
-    /**
-     * Refreshes the activity stream.
-     * The refresh rate is scope.refreshRate.
-     */
-    $scope.refresh = function() {
-      $scope.addNewActivities('newActivities');
-    };
-    // Start the activity stream refresh.
-    $scope.refreshing = $interval($scope.refresh, $scope.refreshRate);
-
-    /**
-     * Adds newly fetched activities to either to the activity-stream or the load button,
-     * Depending on if the current user added an activity or it's fetched from the server.
-     *
-     * @param type
-     *  Determines to which variable the new activity should be added,
-     *  existingActivities: The new activity will be added straight to the activity stream. (Highlighted as well)
-     *  newActivities: The "new posts" notification button will appear in the user's activity stream.
-     */
-    $scope.addNewActivities = function(type) {
-      if (type == 'existingActivities') {
-        // Merge all the loaded activities before adding the created one.
-        $scope.showNewActivities();
-      }
-
-      var activityStreamInfo = {
-        group: $scope.data.group,
-        lastId: $scope.stream.lastLoadedID
-      };
-
-      // Don't send a request when data is missing.
-      if(!activityStreamInfo.lastId || !activityStreamInfo.group) {
-        // If last ID is 0, this is a new group and there's no activities.
-        if(activityStreamInfo.lastId != 0) {
-          $scope.stream.status = 500;
-          return false;
-        }
-      }
-
-      // Call the update stream method.
-      EntityResource.updateStream(activityStreamInfo)
-        .success( function (data, status) {
-          // Update the stream status.
-          $scope.stream.status = status;
-
-          // Update if there's new activities.
-          if (data.data) {
-            // Count the activities that were fetched.
-            var position = 0;
-            angular.forEach(data.data, function (activity) {
-              this.splice(position, 0, {
-                id: activity.id,
-                html: $sce.trustAsHtml(activity.html)
-              });
-              position++;
-            }, $scope[type]);
-
-            // Update the last loaded ID.
-            // Only if there's new activities from the server.
-            $scope.stream.lastLoadedID = $scope[type][0].id ? $scope[type][0].id : $scope.stream.lastLoadedID;
-          }
-        })
-        .error( function (data, status) {
-          // Update the stream status if we get an error, This will display the error message.
-          $scope.stream.status = status;
-        });
-    };
-
-    /**
-     * Merge the "new activity" with the existing activity stream.
-     * When a user has clicked on the "new posts", we grab the activities in the "new activity" group and push them to the top of the "existing activity", and clear the "new activity" group.
-     */
-    $scope.showNewActivities = function() {
-      var position = 0;
-      angular.forEach ($scope.newActivities, function (activity) {
-        this.splice(position, 0, {
-          id: activity.id,
-          created: activity.created,
-          html: activity.html
-        });
-        position++;
-      }, $scope.existingActivities);
-      $scope.newActivities = [];
-    };
 
     /**
      * Prepares the referenced "data" to be objects and normal field to be empty.
@@ -360,11 +258,13 @@ angular.module('c4mApp')
             $scope.serverSide.data = data;
             $scope.serverSide.status = status;
 
-            // Scroll to the top of the page 50px down.
-            angular.element('html, body').animate({scrollTop:50}, '500', 'swing');
+            // Scroll to the top of the activity stream (Reference is the label input).
+            var labelInput = angular.element('#label').offset();
+            angular.element('html, body').animate({scrollTop:labelInput.top}, '500', 'swing');
 
             // Add the newly created activity to the stream.
-            $scope.addNewActivities('existingActivities');
+            // By broadcasting the update to the "activity" controller.
+            $rootScope.$broadcast('c4m.activity.update');
 
             // Collapse the quick-post form.
             if(!$scope.fullForm) {

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/services/quick-post.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/services/quick-post.js
@@ -251,13 +251,11 @@ angular.module('c4mApp')
         }
       }, popups);
       // Get the width of the element clicked in the event.
-      var elem_width = angular.element(event.currentTarget).outerWidth();
-      var elemPosition = angular.element(event.target).offset();
-      var elemParentPosition = angular.element(event.target).parent().offset();
+      var elemWidth = angular.element(event.currentTarget).outerWidth();
       // Toggle the visibility variable.
       popups[name] = popups[name] == 0 ? 1 : 0;
       // Move the popover to be at the end of the button.
-      angular.element(".hidden-checkboxes").css('left', elem_width);
+      angular.element(".hidden-checkboxes").css('left', elemWidth);
     };
 
     /**


### PR DESCRIPTION
#327 
* Created a new controller called "Activity". (This will eliminate any unnecessary calls to activity-stream)
* Created a broadcast that communicates between the 2 controllers.
* Fixed the scroll when creating a new activity.
* Optimized the code in the main controller, Because we need to call it in many places, this will make it faster to load.

Adding new activity with the new fixes:
![activity](https://cloud.githubusercontent.com/assets/7369740/5554384/dc170fda-8c5a-11e4-8bd2-d1b2fc37d99d.gif)

