### PR TITLE
CFD-298 : Wrong variable name used in the query.

### DIFF
--- a/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.module
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.module
@@ -274,7 +274,7 @@ function  c4m_features_og_events_upcoming_events_get_events($range, $topics = ar
   }
 
   if (!empty($topics)) {
-    $query->fieldCondition('c4m_related_topics', 'target_id', $topics, 'IN');
+    $query->fieldCondition('c4m_related_topic', 'target_id', $topics, 'IN');
   }
 
   $result = $query


### PR DESCRIPTION
There was a wrong field name used in the query (it's c4m_related_topic not c4m_related_topic**s**).
This caused WSOD due to Exceptions.

See #513