### PR TITLE
CFD-319 : Homepage : group owner is missing in the my groups & suggested groups list

### DIFF
--- a/capacity4more/behat/features/homepage.feature
+++ b/capacity4more/behat/features/homepage.feature
@@ -22,6 +22,12 @@ Feature: Test homepage and activity stream in the homepage
     Then I should see the site homepage
 
   @api
+  Scenario: Logged in user should see group owner in "My Groups" block.
+    Given I am logged in as user "isaacnewton"
+    When  I visit the site homepage
+    And   I should see "Charles Darwin" in the "span.owner" element
+
+  @api
   Scenario: Anonymous user should see button to open the introduction video.
     Given I am an anonymous user
     When I visit the site homepage

--- a/capacity4more/modules/c4m/content/c4m_content_group/c4m_content_group.ds.inc
+++ b/capacity4more/modules/c4m/content/c4m_content_group/c4m_content_group.ds.inc
@@ -104,15 +104,14 @@ function c4m_content_group_ds_field_settings_info() {
         'ft' => array(),
       ),
     ),
-    'c4m_ds_author_first_and_last_name' => array(
+    'c4m_user_first_and_last_name' => array(
       'weight' => '2',
       'label' => 'inline',
-      'format' => 'author_link',
+      'format' => 'linked_user',
       'formatter_settings' => array(
         'ft' => array(
           'func' => 'theme_ds_field_expert',
           'lb' => 'Owned by',
-          'lb-el' => 'span',
           'lb-col' => TRUE,
           'prefix' => '<span class="owner">',
           'suffix' => '</span>',
@@ -212,14 +211,14 @@ function c4m_content_group_ds_layout_settings_info() {
       ),
       'right' => array(
         1 => 'title',
-        2 => 'c4m_ds_author_first_and_last_name',
+        2 => 'c4m_user_first_and_last_name',
         3 => 'c4m_ds_group_members_count',
       ),
     ),
     'fields' => array(
       'c4m_media' => 'left',
       'title' => 'right',
-      'c4m_ds_author_first_and_last_name' => 'right',
+      'c4m_user_first_and_last_name' => 'right',
       'c4m_ds_group_members_count' => 'right',
     ),
     'classes' => array(),


### PR DESCRIPTION
#525 
This was added and styled, apparently not exported correctly.

* Fixed the export.
* Added a test to make sure it's always there.

![selection_072](https://cloud.githubusercontent.com/assets/7369740/6391773/7791063a-bdc2-11e4-9e21-6f1bfab2478e.png)
