### PR TITLE
CFD-415 : The in-the-picture block should not be visible in the Group members section.

### DIFF
--- a/capacity4more/modules/c4m/features/c4m_features_overview_articles/c4m_features_overview_articles.context.inc
+++ b/capacity4more/modules/c4m/features/c4m_features_overview_articles/c4m_features_overview_articles.context.inc
@@ -49,7 +49,6 @@ function c4m_features_overview_articles_context_default_contexts() {
     'views' => array(
       'values' => array(
         'c4m_overview_articles' => 'c4m_overview_articles',
-        'c4m_overview_og_members:page' => 'c4m_overview_og_members:page',
       ),
     ),
   );

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_members/c4m_features_og_members.context.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_members/c4m_features_og_members.context.inc
@@ -26,6 +26,12 @@ function c4m_features_og_members_context_default_contexts() {
   $context->reactions = array(
     'block' => array(
       'blocks' => array(
+        'views-3ea5d2361b53bfac9a8a2c7de319e7ad' => array(
+          'module' => 'views',
+          'delta' => '3ea5d2361b53bfac9a8a2c7de319e7ad',
+          'region' => 'content_top',
+          'weight' => '-10',
+        ),
         'views-19b677fbcbbec75280a91661ff86b178' => array(
           'module' => 'views',
           'delta' => '19b677fbcbbec75280a91661ff86b178',
@@ -89,6 +95,12 @@ function c4m_features_og_members_context_default_contexts() {
   $context->reactions = array(
     'block' => array(
       'blocks' => array(
+        'views-3ea5d2361b53bfac9a8a2c7de319e7ad' => array(
+          'module' => 'views',
+          'delta' => '3ea5d2361b53bfac9a8a2c7de319e7ad',
+          'region' => 'content_top',
+          'weight' => '-10',
+        ),
         'views-19b677fbcbbec75280a91661ff86b178' => array(
           'module' => 'views',
           'delta' => '19b677fbcbbec75280a91661ff86b178',


### PR DESCRIPTION
#582 
Voices & views "In the picture" banner:
![selection_087](https://cloud.githubusercontent.com/assets/7369740/6996142/fe9fa6c6-db7d-11e4-86bf-1d205905b2b0.png)

People & members has a different "In the picture" banner:
![selection_089](https://cloud.githubusercontent.com/assets/7369740/6996143/255235b8-db7e-11e4-8a83-90764aade0a6.png)
![selection_088](https://cloud.githubusercontent.com/assets/7369740/6996146/2c626e7c-db7e-11e4-8140-db6f5c5923e7.png)


