### PR TITLE
CFD-419 theme active facet links

### DIFF
--- a/capacity4more/themes/c4m/kapablo/sass/components/_facets.scss
+++ b/capacity4more/themes/c4m/kapablo/sass/components/_facets.scss
@@ -32,5 +32,16 @@
     a {
       color: $gray-dark;
     }
+    &.expanded a.facetapi-active {
+      @include arrow-image('down', 'highlight-blue', 'before');
+    }
+    &.collapsed a.facetapi-inactive,
+    &.expanded a.facetapi-inactive {
+      @include arrow-image('right', 'highlight-blue', 'before');
+    }
   }
+}
+
+.facetapi-deactivate {
+  float: right;
 }

--- a/capacity4more/themes/c4m/kapablo/theme/search.inc
+++ b/capacity4more/themes/c4m/kapablo/theme/search.inc
@@ -76,3 +76,37 @@ function kapablo_search_api_sorts_list(array $variables) {
 
   return $output;
 }
+
+/**
+ * Implements theme_facetapi_deactivate_widget().
+ */
+function kapablo_facetapi_deactivate_widget($variables) {
+  return '<span class="facetapi-deactivate">x</span>';
+}
+
+/**
+ * Implements theme_facetapi_link_active().
+ */
+function kapablo_facetapi_link_active($variables) {
+
+  // Sanitizes the link text if necessary.
+  $sanitize = empty($variables['options']['html']);
+  $link_text = ($sanitize) ? check_plain($variables['text']) : $variables['text'];
+
+  // Theme function variables fro accessible markup.
+  // @see http://drupal.org/node/1316580
+  $accessible_vars = array(
+    'text' => $variables['text'],
+    'active' => TRUE,
+  );
+
+  // Builds link, passes through t() which gives us the ability to change the
+  // position of the widget on a per-language basis.
+  $replacements = array(
+    '!facetapi_deactivate_widget' => theme('facetapi_deactivate_widget', $variables),
+    '!facetapi_accessible_markup' => theme('facetapi_accessible_markup', $accessible_vars),
+  );
+  $variables['text'] = $link_text . t('!facetapi_deactivate_widget !facetapi_accessible_markup', $replacements);
+  $variables['options']['html'] = TRUE;
+  return theme_link($variables);
+}


### PR DESCRIPTION
Themed active facet links:
- added icons for expandable links
- added "x" to deactivate active facet link

![facetapi-active](https://cloud.githubusercontent.com/assets/1823998/7025252/ad221fc4-dd42-11e4-8568-7c0abac63703.png)
![facetapi-active-all](https://cloud.githubusercontent.com/assets/1823998/7025251/ad216e62-dd42-11e4-85bf-50f58305bb70.png)
![facetapi-inactive](https://cloud.githubusercontent.com/assets/1823998/7025253/ad2497c2-dd42-11e4-9087-b0d51925e8fb.png)


