### PR TITLE
CFD-420 Make the external contributor url optional

### DIFF
--- a/capacity4more/modules/c4m/content/c4m_content_article/c4m_content_article.features.field_instance.inc
+++ b/capacity4more/modules/c4m/content/c4m_content_article/c4m_content_article.features.field_instance.inc
@@ -484,7 +484,7 @@ function c4m_content_article_field_default_field_instances() {
       'title_label_use_field_label' => 0,
       'title_maxlength' => 128,
       'title_value' => '',
-      'url' => 0,
+      'url' => 'optional',
       'user_register_form' => FALSE,
       'validate_url' => 1,
     ),


### PR DESCRIPTION
It's possible to make the url optional:

![external contributor optional url](https://cloud.githubusercontent.com/assets/1823998/7040577/f1cdb3c0-ddd0-11e4-9391-fbdde3ecea4e.png)
