### PR TITLE
CFD-336 : invalid vocabularies under page creation form + missing creation button.

### DIFF
--- a/capacity4more/modules/c4m/content/c4m_content_wiki_page/c4m_content_wiki_page.module
+++ b/capacity4more/modules/c4m/content/c4m_content_wiki_page/c4m_content_wiki_page.module
@@ -169,14 +169,16 @@ function c4m_content_wiki_page_form_wiki_page_node_form_alter(&$form, &$form_sta
     if (empty($form['book']['plid']['#type'])
       || $form['book']['plid']['#type'] !== 'select'
     ) {
-      $book = $node->book;
-      $book['bid'] = $group->book['bid'];
-      $book['plid'] = $group->book['mlid'];
-      $form['book']['plid'] = _book_parent_select($book);
+      if (isset($node->book)) {
+        $book = $node->book;
+        $book['bid'] = $group->book['bid'];
+        $book['plid'] = $group->book['mlid'];
+        $form['book']['plid'] = _book_parent_select($book);
+      }
     }
   }
 
-  if ($node->book['nid'] !== $node->book['bid']) {
+  if (isset($node->book) && $node->book['nid'] !== $node->book['bid']) {
     $form['book']['plid']['#description'] = t('The parent page in the book. The
       maximum depth for a book and all child pages is !maxdepth. Some pages in
       the selected book may not be available as parents if selecting them would

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_wiki/includes/c4m_features_og_wiki.theme.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_wiki/includes/c4m_features_og_wiki.theme.inc
@@ -12,8 +12,32 @@
  * @return null|string
  */
 function theme_c4m_features_og_wiki_wiki($variables) {
+  global $user;
+  $output = '';
   if (empty($variables['content'])) {
-    return t('No wiki pages (yet).');
+    $message['element'] = array(
+      '#tag' => 'p',
+      '#attributes' => array(
+        'class' => array('wiki-empty-message'),
+      ),
+      '#value' => t('No wiki pages (yet).'),
+    );
+    $output .= theme_html_tag($message);
+    // Add wiki page button when user has permissions to add a wiki page.
+    if ($group = og_context()) {
+      if (og_user_access('node', $group['gid'], 'administer group', $user)) {
+        $button['element'] = array(
+          '#tag' => 'a',
+          '#attributes' => array(
+            'class' => array('add-wiki-page btn btn-success'),
+            'href' => url('node/add/wiki-page'),
+          ),
+          '#value' => t('Add a new wiki page.'),
+        );
+        $output .= theme_html_tag($button);
+      }
+    }
+    return $output;
   }
 }
 

--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/c4m_restful_quick_post.module
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/c4m_restful_quick_post.module
@@ -248,7 +248,7 @@ function c4m_restful_quick_post_needs_app() {
   // If we are on a node creation form, the app should be loaded.
   $node_types = array_keys(node_type_get_types());
   foreach ($node_types as $bundle) {
-    if ($path === 'node/add/' . $bundle) {
+    if ($path === 'node/add/' . str_replace('_', '-', $bundle)) {
       return TRUE;
     }
   }

--- a/capacity4more/themes/c4m/kapablo/sass/components/_forms.scss
+++ b/capacity4more/themes/c4m/kapablo/sass/components/_forms.scss
@@ -93,7 +93,6 @@ input[type="radio"]:not(old) {
 }
 
 input[type="checkbox"]:not(old) {
-  visibility: hidden;
 
   &:before {
     background: $color-beige;


### PR DESCRIPTION
#612 

* Added a button to add a new wiki page when there's none. (Only to group admins)
* Fixed the "Add a wiki" form vocabularies.
* Fixed checkboxes visibility in FF.
* Fixed error message on add wiki page form, For group admins.

![wiki-2015-04-08_15](https://cloud.githubusercontent.com/assets/7369740/7045018/2d23e0c6-de02-11e4-9266-7ea58a4d18c2.gif)
