### PR TITLE
CFD-394 CFD-395 Email domain entity and admin overview

### DIFF
--- a/capacity4more/capacity4more.info
+++ b/capacity4more/capacity4more.info
@@ -164,3 +164,6 @@ dependencies[] = c4m_document_widget
 
 ; Organic Groups
 dependencies[] = c4m_og_purl
+
+; Email Domains
+dependencies[] = c4m_domain

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.api.php
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.api.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @file
+ * Hooks provided by the C4M Email Domain module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+
+/**
+ * Define validation types for the email domain.
+ */
+function hook_c4m_domain_validators_info() {
+  return array(
+    'c4m_domain_validate_ldap' => array(
+      'name' => t('EC LDAP service'),
+      'description' => t('Validate the email address by passing it to the EC LDAP service.'),
+      'callback' => 'c4m_domain_validate_ldap_check',
+    ),
+  );
+}
+
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.info
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.info
@@ -1,0 +1,5 @@
+name = Email Domain functionalities
+description = This module defines a custom entity type that specifies how email domains are validated.
+core = 7.x
+package = capacity4more - Domain
+version = 7.x-1.x-dev

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.info
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.info
@@ -1,5 +1,6 @@
 name = Email Domain functionalities
-description = This module defines a custom entity type that specifies how email domains are validated.
+description = Identify specific email domains and their validation mechanism. This to validate if the email address of a user is still valid.
 core = 7.x
 package = capacity4more - Domain
 version = 7.x-1.x-dev
+dependencies[] = entity

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.install
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.install
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @file
+ * Installation hooks for the C4M Email Domain module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function c4m_domain_schema() {
+  $schema = array();
+
+  $schema['c4m_domain'] = array(
+    'description' => 'The base table for the Email Domains entity',
+    'fields' => array(
+      'id' => array(
+        'description' => 'Primary key of the Email Domains entity',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ),
+      'name' => array(
+        'description' => 'The domain part of the email address.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+      'description' => array(
+        'description' => 'Short description explaining what the domain is about.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+      'validator' => array(
+        'description' => 'The validation type to validate if an email address with this domain is valid.',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+      ),
+    ),
+    'primary key' => array('id'),
+  );
+
+  return $schema;
+}

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.module
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.module
@@ -56,3 +56,204 @@ function c4m_domain_validators_info() {
   // Return all data.
   return $data;
 }
+
+/**
+ * Implements hook_entity_info().
+ */
+function c4m_domain_entity_info() {
+  $info = array();
+
+  $info['c4m_domain'] = array(
+    'label' => t('Email Domains'),
+    'base table' => 'c4m_domain',
+    'entity keys' => array(
+      'id' => 'id',
+      'label' => 'name',
+    ),
+    'entity class' => 'C4mDomainEntity',
+    'controller class' => 'EntityAPIController',
+    'access callback' => 'c4m_domain_access_callback',
+    'uri callback' => 'entity_class_uri',
+    'admin ui' => array(
+      'path' => 'admin/c4m/domains',
+      'controller class' => 'EntityDefaultUIController',
+    ),
+    'fieldable' => TRUE,
+    'bundles' => array(
+      'c4m_domain' => array(
+        'label' => t('Domain'),
+        'admin' => array(
+          'path' => 'admin/c4m/domains',
+        ),
+      ),
+    ),
+    'views controller class' => 'EntityDefaultViewsController',
+    'module' => 'c4m_domain',
+    'fieldable' => FALSE,
+  );
+
+  return $info;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function c4m_domain_menu() {
+  $items = array();
+
+  $items['domain/%'] = array(
+    'title' => 'Domain',
+    'page callback' => 'c4m_domain_view_domain',
+    'page arguments' => array(1),
+    'access arguments' => array('administer site configuration'),
+  );
+
+  return $items;
+}
+
+/**
+ * Access callback for domain entities.
+ */
+function c4m_domain_access_callback($op, $domain = NULL, $account = NULL) {
+  if ($op == 'view' || $op == 'update' || $op == 'create' || $op == 'delete') {
+    return TRUE;
+  }
+  else {
+    return FALSE;
+  }
+}
+
+/**
+ * Callback function for displaying an individual domain.
+ */
+function c4m_domain_view_domain($id) {
+  // Lookup the id.
+  $domains = entity_load('c4m_domain', array(intval($id)));
+  if (empty($domains[$id])) {
+    drupal_not_found();
+    exit;
+  }
+
+  // Render output.
+  $domain = $domains[$id];
+  drupal_set_title($domain->name);
+  $output = entity_view('c4m_domain', array($domain));
+
+  return $output;
+}
+
+/**
+ * Form definition for adding / editing a domain.
+ */
+function c4m_domain_form($form, &$form_state, $domain = NULL) {
+  $form = array();
+
+  $form['name'] = array(
+    '#title' => t('Domain name'),
+    '#description' => t('The domain part of the email address.'),
+    '#type' => 'textfield',
+    '#default_value' => isset($domain->name) ? $domain->name : '',
+    '#required' => TRUE,
+    '#maxlength' => 255,
+  );
+
+  $form['description'] = array(
+    '#title' => t('Description'),
+    '#description' => t('Short description explaining what the domain is about.'),
+    '#type' => 'textarea',
+    '#default_value' => isset($domain->description) ? $domain->description : '',
+    '#required' => TRUE,
+  );
+
+  $options = array_keys(c4m_domain_entity_info());
+  $form['validator'] = array(
+    '#title' => t('Validator'),
+    '#description' => t('The validation type to validate if an email address with this domain is valid.'),
+    '#type' => 'select',
+    '#options' => $options,
+    '#default_value' => isset($domain->deadline) ? $domain->deadline : '',
+    '#required' => TRUE,
+  );
+
+  field_attach_form('c4m_domain', $domain, $form, $form_state);
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => isset($domain->id) ? t('Update domain') : t('Save domain'),
+    '#weight' => 50,
+  );
+
+  return $form;
+}
+
+/**
+ * Validation handler for the domain add/edit form.
+ */
+function c4m_domain_form_validate($form, &$form_state) {
+  $test_email = 'test@' . $form_state['values']['name'];
+  if (!valid_email_address($test_email)) {
+    form_set_error('name', t('The domain name is invalid.'));
+  }
+  if (strlen($form_state['values']['description']) > 255) {
+    form_set_error('description', t('The description contains more than 255 characters.'));
+  }
+}
+
+/**
+ * Submit handler for the domain add/edit form.
+ */
+function c4m_domain_form_submit($form, &$form_state) {
+  $domain = entity_ui_form_submit_build_entity($form, $form_state);
+  $domain->save();
+  drupal_set_message(t('The domain: @name has been saved.', array('@name' => $domain->name)));
+  $form_state['redirect'] = 'admin/c4m/domains';
+}
+
+/**
+ * Implements hook_entity_property_info().
+ */
+function c4m_domain_entity_property_info() {
+  $info = array();
+
+  $info['c4m_domain']['properties']['id'] = array(
+    'label' => t('Domain ID'),
+    'description' => t('The ID of the domain.'),
+    'type' => 'integer',
+    'schema field' => 'id',
+  );
+
+  $info['c4m_domain']['properties']['name'] = array(
+    'label' => t('Domain name'),
+    'description' => t('The domain part of the email address.'),
+    'type' => 'text',
+    'schema field' => 'name',
+  );
+  $info['c4m_domain']['properties']['description'] = array(
+    'label' => t('Description'),
+    'description' => t('Short description explaining what the domain is about.'),
+    'type' => 'text',
+    'schema field' => 'description',
+  );
+  $info['c4m_domain']['properties']['validator'] = array(
+    'label' => t('Validator'),
+    'description' => t('The validation type to validate if an email address with this domain is valid.'),
+    'type' => 'text',
+    'schema field' => 'validator',
+  );
+
+  return $info;
+}
+
+/**
+ * C4mDomain entity class extending the Entity class.
+ */
+class C4mDomainEntity extends Entity {
+
+  /**
+   * Change the default URI from default/id to c4m_domain/id.
+   */
+  protected function defaultUri() {
+    return array('path' => 'admin/c4m/domains/manage/' . $this->identifier());
+  }
+
+}

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.module
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.module
@@ -1,0 +1,5 @@
+<?php
+/**
+ * @file
+ * Code for the C4M Email Domain module.
+ */

--- a/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.module
+++ b/capacity4more/modules/c4m/domain/c4m_domain/c4m_domain.module
@@ -3,3 +3,56 @@
  * @file
  * Code for the C4M Email Domain module.
  */
+
+/**
+ * Implements hook_c4m_domain_validators_info().
+ */
+function c4m_domain_c4m_domain_validators_info() {
+  return array(
+    'c4m_domain_validate_email' => array(
+      'name' => t('E-mail domain'),
+      'description' => t('Validate the domain matches the given email address.'),
+      'callback' => 'c4m_domain_validate_email',
+    ),
+  );
+}
+
+/**
+ * Callback for hook_c4m_domain_validators_info.
+ *
+ * @param string $email
+ *   The email address to validate.
+ *
+ * @return bool
+ *   Whether the domain is valid or not.
+ */
+function c4m_domain_validate_email($email) {
+  return TRUE;
+}
+
+/**
+ * Retrieve a list of domain validators.
+ *
+ * @return array
+ *   Validators information as collected trough the implemented
+ *   hook_c4m_domain_validators_info hooks.
+ */
+function c4m_domain_validators_info() {
+  $cache_key  = 'c4m_domain:validators_info';
+  $data = &drupal_static($cache_key);
+
+  // Retrieve from Cache if not loaded before.
+  if (!isset($data)) {
+    if (($cache = cache_get($cache_key)) && !empty($cache->data)) {
+      $data = $cache->data;
+    }
+    else {
+      $hook = 'hook_c4m_domain_validators_info';
+      $data = module_invoke_all($hook);
+      cache_set($cache_key, $data);
+    }
+  }
+
+  // Return all data.
+  return $data;
+}


### PR DESCRIPTION
Implemented new entity and admin overview for email domains: c4m_domain

![admin domains](https://cloud.githubusercontent.com/assets/1823998/7224829/a581d71a-e737-11e4-98c4-32f449aed813.png)
![edit domain](https://cloud.githubusercontent.com/assets/1823998/7224831/ab7457a6-e737-11e4-8462-3a4aeeb3cf85.png)
