### PR TITLE
CFD-354 : Cannot upload a new banner/image once previous is removed

### DIFF
--- a/capacity4more/modules/c4m/admin/c4m_admin_groups/c4m_admin_groups.module
+++ b/capacity4more/modules/c4m/admin/c4m_admin_groups/c4m_admin_groups.module
@@ -5,3 +5,11 @@
  */
 
 include_once 'c4m_admin_groups.features.inc';
+
+/**
+ * Implements hook_init().
+ */
+function c4m_admin_groups_init() {
+  $settings['machineName'] = array();
+  drupal_add_js($settings, 'setting');
+}


### PR DESCRIPTION
Machine-name script creates an error when trying to get the ajax form after removing the previous image.
Creates an undefined object, added a small script to make sure machineName object is never undefined.

![re-upload-2015-04-20_16](https://cloud.githubusercontent.com/assets/7369740/7231226/d205f7f4-e77c-11e4-8376-d72ce6f2e00c.gif)
