### PR TITLE
CFD-354 : Cannot upload a new banner/image once previous is removed - Fix

### DIFF
--- a/capacity4more/modules/c4m/admin/c4m_admin_groups/c4m_admin_groups.module
+++ b/capacity4more/modules/c4m/admin/c4m_admin_groups/c4m_admin_groups.module
@@ -7,9 +7,13 @@
 include_once 'c4m_admin_groups.features.inc';
 
 /**
- * Implements hook_init().
+ * Implements hook_form_alter().
+ *
+ * Add "machineName" empty array to the JS settings to avoid undefined object being sent to the jQuery.
  */
-function c4m_admin_groups_init() {
-  $settings['machineName'] = array();
-  drupal_add_js($settings, 'setting');
+function c4m_admin_groups_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'project_node_form' || $form_id == 'group_node_form') {
+    $settings['machineName'] = array();
+    drupal_add_js($settings, 'setting');
+  }
 }


### PR DESCRIPTION
Follow up on #653

This will load the fix only when needed 
- Group add/edit form
- Project add/edit form