### PR TITLE
CFD-282 group page fieldset not collapse

### DIFF
--- a/capacity4more/modules/c4m/content/c4m_content_group/js/group-details.js
+++ b/capacity4more/modules/c4m/content/c4m_content_group/js/group-details.js
@@ -7,7 +7,7 @@
   function ($) {
     Drupal.behaviors.groupDetails = {
       attach: function(context, settings) {
-        $('fieldset.collapsible', context).once('collapse', function () {
+        $('fieldset.collapsible', context).once('collapseGroupDetails', function () {
           var $fieldset = $(this);
 
           // Prevent default behaviour of collapsible field kicking in.

--- a/capacity4more/themes/c4m/kapablo/sass/components/_group_blocks.scss
+++ b/capacity4more/themes/c4m/kapablo/sass/components/_group_blocks.scss
@@ -46,11 +46,6 @@
 
     background: none;
     border: 0;
-    height: auto;
-
-    &.collapsed {
-      height: auto;
-    }
 
     legend {
       @include box-shadow(none);


### PR DESCRIPTION
The bootstrap collapse js wasn't being executed because the custom group details behavior used the same class name in the 'once' function and so prevented bootstrap

![image](https://cloud.githubusercontent.com/assets/2338753/7270552/420c8cbe-e8dd-11e4-9585-60ae70ce4f1b.png)
