### PR TITLE
CFD-331 Add 'Add an event' button in the header of the event overview

### DIFF
--- a/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.context.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.context.inc
@@ -30,19 +30,19 @@ function c4m_features_og_events_context_default_contexts() {
           'module' => 'views',
           'delta' => '3e9a9707eba7963ecaa8b99564d20039',
           'region' => 'content',
-          'weight' => '-10',
+          'weight' => '1',
         ),
         'views-5218f8132a449400191061a0818719a1' => array(
           'module' => 'views',
           'delta' => '5218f8132a449400191061a0818719a1',
           'region' => 'content',
-          'weight' => '-9',
+          'weight' => '2',
         ),
         'views-1616c88372ab872314baee532830c643' => array(
           'module' => 'views',
           'delta' => '1616c88372ab872314baee532830c643',
           'region' => 'content',
-          'weight' => '-8',
+          'weight' => '3',
         ),
         'views-5cece47fc853c63eb27c1cd4604667de' => array(
           'module' => 'views',

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.views_default.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.views_default.inc
@@ -305,6 +305,23 @@ function c4m_features_og_events_views_default_views() {
   $handler = $view->new_display('page', 'Page', 'page');
   $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['exposed_block'] = TRUE;
+  $handler->display->display_options['defaults']['header'] = FALSE;
+  /* Header: Number of items */
+  $handler->display->display_options['header']['result']['id'] = 'result';
+  $handler->display->display_options['header']['result']['table'] = 'views';
+  $handler->display->display_options['header']['result']['field'] = 'result';
+  $handler->display->display_options['header']['result']['ui_name'] = 'Number of items';
+  $handler->display->display_options['header']['result']['empty'] = TRUE;
+  $handler->display->display_options['header']['result']['content'] = '@total in total';
+  /* Header: Add event link */
+  $handler->display->display_options['header']['c4m_views_node_add']['id'] = 'c4m_views_node_add';
+  $handler->display->display_options['header']['c4m_views_node_add']['table'] = 'views';
+  $handler->display->display_options['header']['c4m_views_node_add']['field'] = 'c4m_views_node_add';
+  $handler->display->display_options['header']['c4m_views_node_add']['ui_name'] = 'Add event link';
+  $handler->display->display_options['header']['c4m_views_node_add']['label'] = 'Add an event';
+  $handler->display->display_options['header']['c4m_views_node_add']['empty'] = TRUE;
+  $handler->display->display_options['header']['c4m_views_node_add']['node_type'] = 'event';
+  $handler->display->display_options['header']['c4m_views_node_add']['link_text'] = 'Add an event';
   $handler->display->display_options['defaults']['footer'] = FALSE;
   /* Footer: Global: Add view pages links */
   $handler->display->display_options['footer']['c4m_views_switch_page']['id'] = 'c4m_views_switch_page';
@@ -336,14 +353,6 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['header']['result']['ui_name'] = 'Number of items';
   $handler->display->display_options['header']['result']['empty'] = TRUE;
   $handler->display->display_options['header']['result']['content'] = '@total in total';
-  /* Header: Add event link */
-  $handler->display->display_options['header']['c4m_views_node_add']['id'] = 'c4m_views_node_add';
-  $handler->display->display_options['header']['c4m_views_node_add']['table'] = 'views';
-  $handler->display->display_options['header']['c4m_views_node_add']['field'] = 'c4m_views_node_add';
-  $handler->display->display_options['header']['c4m_views_node_add']['ui_name'] = 'Add event link';
-  $handler->display->display_options['header']['c4m_views_node_add']['label'] = 'Add an event';
-  $handler->display->display_options['header']['c4m_views_node_add']['node_type'] = 'event';
-  $handler->display->display_options['header']['c4m_views_node_add']['link_text'] = 'Add an event';
   $handler->display->display_options['defaults']['footer'] = FALSE;
   /* Footer: Link to group upcoming events page */
   $handler->display->display_options['footer']['c4m_views_custom_link']['id'] = 'c4m_views_custom_link';

--- a/capacity4more/themes/c4m/kapablo/sass/components/_event.scss
+++ b/capacity4more/themes/c4m/kapablo/sass/components/_event.scss
@@ -6,11 +6,19 @@
 }
 .view-c4m-overview-events-landing, .view-c4m-overview-og-events-landing {
   position: relative;
-  .view-header {
-    position: absolute;
-    right: 0px;
-    top: -50px;
+
+  &.view-display-id-block_2 {
+    .view-header {
+      position: absolute;
+      right: 0px;
+      top: -50px;
+    }
   }
+
+  .view-header {
+    margin: 0;
+  }
+
   a.link-to-view {
     float: right;
     span {

--- a/capacity4more/themes/c4m/kapablo/sass/components/_views.scss
+++ b/capacity4more/themes/c4m/kapablo/sass/components/_views.scss
@@ -13,6 +13,7 @@
 .view-header {
   color: $gray-dark;
   margin: 10px 0 25px 0;
+  @include clearfix;
 
   .node-create {
     @include input-rounded($highlight-blue, 25px);
@@ -24,7 +25,7 @@
 
     @media screen and (min-width: $screen-md-min) {
       float: right;
-      margin-top: -51px;
+      //margin-top: -51px;
     }
 
     &.node-create-discussion {


### PR DESCRIPTION
Added 'Add an event' button in the header of the event overview page-view and removed the button from the upcomming-events block
Updated 'Add an event' button css for better layout
Rearanged weights of group events overview blocks so they come under the page content

![image](https://cloud.githubusercontent.com/assets/2338753/7274779/0a0a40a4-e900-11e4-9ff5-2455367f7d13.png)
