### PR TITLE
CFD-349 - events without a location

### DIFF
--- a/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
+++ b/capacity4more/modules/c4m/restful/c4m_restful_quick_post/components/c4m-app/src/controllers/main.js
@@ -294,12 +294,6 @@ angular.module('c4mApp')
               }
             });
           }
-          else {
-            // Use default latitude and longitude of Brussels, Belgium.
-            submitData.location.lat = 50.850339600000000000;
-            submitData.location.lng = 4.351710300000036000;
-            submitData.location.country = 'BE';
-          }
           // Continue submitting form.
           checkForm(submitData, resource, resourceFields, type);
         });


### PR DESCRIPTION
When no location is set in an event via quickpost, don't set a default (to Brussels)
