### PR TITLE
CFD-481 Fix wiki dropdown on group homepage

### DIFF
--- a/capacity4more/themes/c4m/kapablo/theme/menu.inc
+++ b/capacity4more/themes/c4m/kapablo/theme/menu.inc
@@ -68,6 +68,7 @@ function kapablo_menu_link__c4m_og_menu(array $variables) {
       $element['#localized_options']['attributes']['data-target'] = '#';
       $element['#localized_options']['attributes']['class'][] = 'dropdown-toggle';
       $element['#localized_options']['attributes']['data-toggle'] = 'dropdown';
+      $element['#localized_options']['attributes']['data-disabled'] = 'true';
     }
   }
 


### PR DESCRIPTION
Issue occurs when using bootstrap.js and AngularJS together
http://stackoverflow.com/a/28610640

Fix by adding:
$element['#localized_options']['attributes']['data-disabled'] = 'true';