### PR TITLE
CFD-507 Search : Show "order by relevance" only when a search term is entered

### DIFF
--- a/capacity4more/behat/features/bootstrap/FeatureContext/Search.php
+++ b/capacity4more/behat/features/bootstrap/FeatureContext/Search.php
@@ -29,7 +29,7 @@ trait Search {
    */
   public function iShouldSeeTheSidebarSearch() {
     $page = $this->getSession()->getPage();
-    $el = $page->find('css', '.region-sidebar-first #edit-search-api-views-fulltext');
+    $el = $page->find('css', '.region-sidebar-first #edit-text');
     if ($el === null) {
       throw new \Exception('The Sidebar Search block is not visible.');
     }

--- a/capacity4more/modules/c4m/features/c4m_features_overview_articles/c4m_features_overview_articles.views_default.inc
+++ b/capacity4more/modules/c4m/features/c4m_features_overview_articles/c4m_features_overview_articles.views_default.inc
@@ -80,7 +80,7 @@ function c4m_features_overview_articles_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features/c4m_features_overview_events/c4m_features_overview_events.views_default.inc
+++ b/capacity4more/modules/c4m/features/c4m_features_overview_events/c4m_features_overview_events.views_default.inc
@@ -79,7 +79,7 @@ function c4m_features_overview_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -131,7 +131,7 @@ function c4m_features_overview_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -190,7 +190,7 @@ function c4m_features_overview_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -276,7 +276,7 @@ function c4m_features_overview_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -357,7 +357,7 @@ function c4m_features_overview_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -427,7 +427,7 @@ function c4m_features_overview_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features/c4m_features_overview_groups/c4m_features_overview_groups.views_default.inc
+++ b/capacity4more/modules/c4m/features/c4m_features_overview_groups/c4m_features_overview_groups.views_default.inc
@@ -76,7 +76,7 @@ function c4m_features_overview_groups_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features/c4m_features_overview_people/c4m_features_overview_people.views_default.inc
+++ b/capacity4more/modules/c4m/features/c4m_features_overview_people/c4m_features_overview_people.views_default.inc
@@ -82,7 +82,7 @@ function c4m_features_overview_people_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_discussions/c4m_features_og_discussions.views_default.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_discussions/c4m_features_og_discussions.views_default.inc
@@ -101,7 +101,7 @@ function c4m_features_og_discussions_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_documents/c4m_features_og_documents.views_default.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_documents/c4m_features_og_documents.views_default.inc
@@ -126,7 +126,7 @@ function c4m_features_og_documents_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -242,7 +242,7 @@ function c4m_features_og_documents_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Fulltext search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.views_default.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_events/c4m_features_og_events.views_default.inc
@@ -101,7 +101,7 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -153,7 +153,7 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -206,7 +206,7 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -303,7 +303,7 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -401,7 +401,7 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
@@ -471,7 +471,7 @@ function c4m_features_og_events_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Browse';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/features_og/c4m_features_og_members/c4m_features_og_members.views_default.inc
+++ b/capacity4more/modules/c4m/features_og/c4m_features_og_members/c4m_features_og_members.views_default.inc
@@ -91,7 +91,7 @@ function c4m_features_og_members_views_default_views() {
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator_id'] = 'search_api_views_fulltext_op';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['label'] = 'Fulltext search';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['operator'] = 'search_api_views_fulltext_op';
-  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'search_api_views_fulltext';
+  $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['identifier'] = 'text';
   $handler->display->display_options['filters']['search_api_views_fulltext']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,

--- a/capacity4more/modules/c4m/search/c4m_search/c4m_search.features.inc
+++ b/capacity4more/modules/c4m/search/c4m_search/c4m_search.features.inc
@@ -416,6 +416,19 @@ function c4m_search_default_search_api_sort() {
     "options" : { "field_name" : "Number of views" },
     "rdf_mapping" : []
   }');
+  $items['c4m_search_users__search_api_relevance'] = entity_import('search_api_sort', '{
+    "index_id" : "c4m_search_users",
+    "field" : "search_api_relevance",
+    "name" : "Relevance",
+    "enabled" : "1",
+    "weight" : "0",
+    "identifier" : "c4m_search_users__search_api_relevance",
+    "default_sort" : "0",
+    "default_sort_no_terms" : "0",
+    "default_order" : "desc",
+    "options" : { "field_name" : "search_api_relevance" },
+    "rdf_mapping" : []
+  }');
   $items['c4m_search_users__c4m_first_name'] = entity_import('search_api_sort', '{
     "index_id" : "c4m_search_users",
     "field" : "c4m_first_name",

--- a/capacity4more/modules/c4m/search/c4m_search/c4m_search.module
+++ b/capacity4more/modules/c4m/search/c4m_search/c4m_search.module
@@ -264,3 +264,42 @@ function c4m_search_facetapi_searcher_info_alter(array &$searcher_info) {
     }
   }
 }
+
+/**
+ * Implements hook_search_api_sorts_alter().
+ *
+ * Show sort by relevance only when a search term is entered.
+ */
+function c4m_search_search_api_sorts_alter(&$block, $view) {
+  $params = drupal_get_query_parameters();
+
+  if (empty($params['search_api_views_fulltext'])) {
+    foreach ($block['content']['#items'] as $key => $item) {
+      if (isset($item['#options']['query']['sort'])
+        && $item['#options']['query']['sort'] === 'search_api_relevance') {
+        unset($block['content']['#items'][$key]);
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_search_api_sorts_get_default_sort_alter().
+ *
+ * Make sort by relevance the default sort when a term is entered
+ * without a manual sort being selected.
+ */
+function c4m_search_search_api_sorts_get_default_sort_alter(&$default_sort, $search_sorts, $keys) {
+  dsm('c4m_search_search_api_sorts_get_default_sort_alter');
+  $params = drupal_get_query_parameters();
+
+  if (empty($params['sort']) && !empty($params['search_api_views_fulltext'])) {
+    foreach ($search_sorts as $search_sort) {
+      if ($search_sort->field === 'search_api_relevance') {
+        $search_sort->default_order = 'desc';
+        $default_sort = $search_sort;
+        break;
+      }
+    }
+  }
+}

--- a/capacity4more/modules/c4m/search/c4m_search/c4m_search.module
+++ b/capacity4more/modules/c4m/search/c4m_search/c4m_search.module
@@ -273,7 +273,7 @@ function c4m_search_facetapi_searcher_info_alter(array &$searcher_info) {
 function c4m_search_search_api_sorts_alter(&$block, $view) {
   $params = drupal_get_query_parameters();
 
-  if (empty($params['search_api_views_fulltext'])) {
+  if (empty($params['text'])) {
     foreach ($block['content']['#items'] as $key => $item) {
       if (isset($item['#options']['query']['sort'])
         && $item['#options']['query']['sort'] === 'search_api_relevance') {
@@ -292,7 +292,7 @@ function c4m_search_search_api_sorts_alter(&$block, $view) {
 function c4m_search_search_api_sorts_get_default_sort_alter(&$default_sort, $search_sorts, $keys) {
   $params = drupal_get_query_parameters();
 
-  if (empty($params['sort']) && !empty($params['search_api_views_fulltext'])) {
+  if (empty($params['sort']) && !empty($params['text'])) {
     foreach ($search_sorts as $search_sort) {
       if ($search_sort->field === 'search_api_relevance') {
         $search_sort->default_order = 'desc';

--- a/capacity4more/modules/c4m/search/c4m_search/c4m_search.module
+++ b/capacity4more/modules/c4m/search/c4m_search/c4m_search.module
@@ -290,7 +290,6 @@ function c4m_search_search_api_sorts_alter(&$block, $view) {
  * without a manual sort being selected.
  */
 function c4m_search_search_api_sorts_get_default_sort_alter(&$default_sort, $search_sorts, $keys) {
-  dsm('c4m_search_search_api_sorts_get_default_sort_alter');
   $params = drupal_get_query_parameters();
 
   if (empty($params['sort']) && !empty($params['search_api_views_fulltext'])) {

--- a/capacity4more/themes/c4m/kapablo/sass/components/_views.scss
+++ b/capacity4more/themes/c4m/kapablo/sass/components/_views.scss
@@ -116,7 +116,7 @@
   clear: both;
 }
 
-#edit-search-api-views-fulltext-wrapper {
+#edit-text-wrapper {
   label {
     color: $color-gray-dark;
     font-size: 30px;


### PR DESCRIPTION
Show sort by relevance only when a search term is entered.
Make sort by relevance the default sort when a term is entered without a manual sort being selected.

![search people](https://cloud.githubusercontent.com/assets/1823998/7531957/3941994a-f561-11e4-86ed-9e33301f2c04.png)
![search people text](https://cloud.githubusercontent.com/assets/1823998/7531956/393f84d4-f561-11e4-8424-2ae5935ca271.png)
