### PR TITLE
CFD-329 : formatting bug on vocabulary lists.

### DIFF
--- a/capacity4more/drupal-org.make
+++ b/capacity4more/drupal-org.make
@@ -52,6 +52,7 @@ projects[entity][patch][] = "https://www.drupal.org/files/issues/2086225-entity-
 
 projects[entityreference][subdir] = "contrib"
 projects[entityreference][version] = "1.1"
+projects[entityreference][patch][] = "https://www.drupal.org/files/entityreference-decode_option_labels-1665818-32_0.patch"
 
 projects[entityreference_prepopulate][subdir] = "contrib"
 projects[entityreference_prepopulate][version] = "1.5"


### PR DESCRIPTION
https://issuetracker.amplexor.com/jira/browse/CFD-329?focusedCommentId=211569&#comment-211569

This fixes Diane's comment.

It was actually a bug in the entity reference module, Applied a patch and it fixed it.

Created a group with special chars in the title:
![selection_122](https://cloud.githubusercontent.com/assets/7369740/7606183/3878f9ac-f95f-11e4-8b63-3bc60b23f20a.png)

And after the fix, in the "subgroup of" field:
![selection_123](https://cloud.githubusercontent.com/assets/7369740/7606216/80b1d78e-f95f-11e4-993a-7a97eb8675f1.png)

In the admin allowed values:
![selection_124](https://cloud.githubusercontent.com/assets/7369740/7606222/8e36e80e-f95f-11e4-9221-778f057833be.png)
 
Another example:
![selection_125](https://cloud.githubusercontent.com/assets/7369740/7606227/96b37862-f95f-11e4-940b-1f382066e3fd.png)
