### PR TITLE
Fix behat tests failing on stdClass::$role...

### DIFF
--- a/build/travis/config/config.sh.travis
+++ b/build/travis/config/config.sh.travis
@@ -22,7 +22,7 @@ BASE_DOMAIN_URL="127.0.0.1:8080"
 # Modify the login details below to be the desired 
 # login details for the Drupal Administrator account.
 ADMIN_USERNAME="admin"
-ADMIN_PASSWORD="admin"
+ADMIN_PASSWORD="drupal"
 ADMIN_EMAIL="capacity4more@local.dev"
 
 

--- a/capacity4more/behat/behat.yml
+++ b/capacity4more/behat/behat.yml
@@ -3,7 +3,7 @@ default:
     parameters:
       drupal_users:
         admin:
-          'admin'
+          'drupal'
         mariecurie:
           'drupal'
         isaacnewton:


### PR DESCRIPTION
Notice: Undefined property: stdClass::$role in vendor/drupal/drupal-extension/src/Drupal/DrupalExtension/Context/DrupalContext.php line 337

Install scripts creates an "admin" user with password "drupal". Behat assumed password "admin"