### PR TITLE
CFM-1192: Create view block to display suggested groups

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/c4m_features_homepage.module
+++ b/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/c4m_features_homepage.module
@@ -96,8 +96,8 @@ function c4m_features_homepage_c4m_suggested_groups_get_groups() {
  * Callback function to be used within uasort to order alphabetically nodes.
  */
 function c4m_features_homepage_node_sort_by_title($first_node, $second_node) {
-  // strcasecmp can't be used directly on uasort, as we need to get the node
-  // title.
+  // Function strcasecmp can't be used directly on uasort, as we need to get
+  // the node title.
   return strcasecmp($first_node->title, $second_node->title);
 }
 

--- a/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/c4m_features_homepage.module
+++ b/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/c4m_features_homepage.module
@@ -54,27 +54,51 @@ function c4m_features_homepage_c4m_suggested_groups_get_groups() {
       ->propertyCondition('nid', $user_groups['node'], 'NOT IN');
   }
 
+  $link_filters = array();
   if (!empty($interests)) {
     $query->fieldCondition('c4m_vocab_topic', 'tid', $interests, 'IN');
+
+    // Adds each interest to the exposed filters that will be pass to the
+    // groups page.
+    foreach ($interests as $key => $interest) {
+      $link_filters['f[' . $key . ']'] = 'c4m_vocab_topic:' . $interest;
+    }
   }
 
   $result = $query
     ->addTag('random')
-    ->range(0, 3)
+    ->range(0, 5)
     ->execute();
 
   if (empty($result['node'])) {
     return;
   }
 
+  // After selecting 5 random groups, they are ordered alphabetically.
+  $nodes = array();
   foreach ($result['node'] as $group) {
-    $node_view = node_view(node_load($group->nid), 'block_list');
+    $nodes[] = node_load($group->nid);
+  }
+  uasort($nodes, 'c4m_features_homepage_node_sort_by_title');
+
+  foreach ($nodes as $group) {
+    $node_view = node_view($group, 'block_list');
     $groups .= drupal_render($node_view);
   }
 
   $variables['groups'] = $groups;
+  $variables['link'] = url('groups', array('absolute' => TRUE, 'query' => $link_filters));
 
   return theme('c4m_features_homepage_c4m_suggested_groups', $variables);
+}
+
+/**
+ * Callback function to be used within uasort to order alphabetically nodes.
+ */
+function c4m_features_homepage_node_sort_by_title($first_node, $second_node) {
+  // strcasecmp can't be used directly on uasort, as we need to get the node
+  // title.
+  return strcasecmp($first_node->title, $second_node->title);
 }
 
 /**

--- a/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/plugins/content_types/c4m_suggested_groups/c4m_suggested_groups.inc
+++ b/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/plugins/content_types/c4m_suggested_groups/c4m_suggested_groups.inc
@@ -41,6 +41,7 @@ function c4m_features_homepage_c4m_suggested_groups_content_type_theme(&$theme, 
   $theme['c4m_features_homepage_c4m_suggested_groups'] = array(
     'variables' => array(
       'groups' => NULL,
+      'link' => NULL,
     ),
     'path' => $plugin['path'],
     'template' => 'c4m_suggested_groups',

--- a/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/plugins/content_types/c4m_suggested_groups/c4m_suggested_groups.tpl.php
+++ b/project/profiles/capacity4more/modules/c4m/features/c4m_features_homepage/plugins/content_types/c4m_suggested_groups/c4m_suggested_groups.tpl.php
@@ -11,7 +11,7 @@
     <div class="suggested-groups panel-pane">
       <h2 class="pane-title"><?php print t('Suggested Groups') ?></h2>
       <?php print $groups ?>
-      <a class="see-more-link" href="<?php print url('groups', array('absolute' => TRUE)); ?>">
+      <a class="see-more-link" href="<?php print $link; ?>">
         <?php print t('See more') ?>
         <i class="fa fa-chevron-right"></i>
       </a>


### PR DESCRIPTION
Updates the suggested groups block to display 5 items, order them alphabetically and send the user interests as default filters on the group page.

Issue: https://issuetracker.amplexor.com/jira/browse/CFM-1192

![suggested-groups](https://cloud.githubusercontent.com/assets/877002/17326509/13dd4d06-58b2-11e6-9af6-ccc929186ba9.png)
