### PR TITLE
CFM-922: Show status message

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/user/c4m_user_og/c4m_user_og.module
+++ b/project/profiles/capacity4more/modules/c4m/user/c4m_user_og/c4m_user_og.module
@@ -530,6 +530,7 @@ function c4m_user_og_c4m_vistor_cta($group) {
  */
 function c4m_user_og_c4m_join_cta($group) {
   if (og_is_member('node', $group->nid)) {
+    drupal_set_message(t('Welcome to group %group', array('%group' => $group->title)));
     return;
   }
 


### PR DESCRIPTION
Adds back the drupal_set_message that tells the user about the group membership.

Issue: https://issuetracker.amplexor.com/jira/browse/CFM-922

Seems that the changes from https://github.com/capacity4dev/capacity4more/pull/1064 are lost. New branch created to add them back.

Screenshot:
![welcome-message](https://cloud.githubusercontent.com/assets/877002/17485577/48425876-5d8e-11e6-9c81-f2661ea148e9.png)
