### PR TITLE
CFM-787: Create custom "leave" page

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/user/c4m_user_profile/c4m_user_profile.module
+++ b/project/profiles/capacity4more/modules/c4m/user/c4m_user_profile/c4m_user_profile.module
@@ -1340,3 +1340,31 @@ function c4m_user_profile_get_expertise_topics($uid) {
 
   return $amount;
 }
+
+/**
+ * Implements hook_user_cancel_methods_alter().
+ *
+ * Adds a new cancellation method that reassigns the content to the anonymous
+ * user without deleting the user account.
+ */
+function c4m_user_profile_user_cancel_methods_alter(&$methods) {
+  $methods['user_block_reassign'] = array(
+    'title' => t('Block the account and make its content belong to the %anonymous-name user.', array('%anonymous-name' => variable_get('anonymous', t('Anonymous')))),
+    'description' => t('Your account will be blocked. All of your content will be assigned to the %anonymous-name user.', array('%anonymous-name' => variable_get('anonymous', t('Anonymous')))),
+  );
+}
+
+/**
+ * Implements hook_user_cancel().
+ *
+ * Implements the functionallity for the custom cancellation method that blocks
+ * and reassigns.
+ */
+function c4m_user_profile_user_cancel($edit, $account, $method) {
+  // By default, the cancellation blocks the user, so we only care about the
+  // content reassign that is already implemented in the node hook
+  // implementation.
+  if ($method == 'user_block_reassign') {
+    node_user_cancel($edit, $account, 'user_cancel_reassign');
+  }
+}

--- a/project/profiles/capacity4more/modules/c4m/user/c4m_user_profile/c4m_user_profile.pages.inc
+++ b/project/profiles/capacity4more/modules/c4m/user/c4m_user_profile/c4m_user_profile.pages.inc
@@ -109,7 +109,7 @@ function c4m_user_profile_remove_account_form_submit($form, &$form_state) {
   if ($values['anonymize']) {
     // This cancel method will reassign all the content of the user
     // to the anonymous user.
-    $values['user_cancel_method'] = 'user_cancel_reassign';
+    $values['user_cancel_method'] = 'user_block_reassign';
   }
 
   // This calls the default Drupal workflow for cancelling an account.


### PR DESCRIPTION
Adds new custom cancel method that disables the user and reassigns the content.

Previous PR: https://github.com/capacity4dev/capacity4more/pull/1091
Issue: https://issuetracker.amplexor.com/jira/browse/CFM-787

Pics: 
Confirmation to the user that it's disabled (default Drupal messages):
![galileo-disabled](https://cloud.githubusercontent.com/assets/877002/17513980/6e2806ba-5e30-11e6-940b-e01f63e491b5.png)
User listing shows Galileo as blocked:
![galileo-blocked](https://cloud.githubusercontent.com/assets/877002/17513989/7238bef2-5e30-11e6-913f-deccb62bf3f5.png)
The content appears as anonymous:
![galileo-anonymized](https://cloud.githubusercontent.com/assets/877002/17513994/7614e8ca-5e30-11e6-8b6d-b84021600e57.png)
