### PR TITLE
[CFM-1047] Group entity references fields not correctly autocompleting

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/og/c4m_og/plugins/entityreference/selection/C4MSelectionHandler.class.php
+++ b/project/profiles/capacity4more/modules/c4m/og/c4m_og/plugins/entityreference/selection/C4MSelectionHandler.class.php
@@ -36,7 +36,7 @@ class C4MSelectionHandler extends C4MOgSelectionHandler {
     $match = NULL,
     $match_operator = 'CONTAINS'
   ) {
-    return parent::buildEntityFieldQuery();
+    return parent::buildEntityFieldQuery($match, $match_operator);
   }
 
 }


### PR DESCRIPTION
Fixes issue on autocompletion of references to groups due to not passing the variables to the parent function.

Issue: https://issuetracker.amplexor.com/jira/browse/CFM-1047

Screenshot: 
![autocomplete-bug](https://cloud.githubusercontent.com/assets/877002/17816022/4e4eccc0-6637-11e6-9253-6abc854b60ae.png)
