### PR TITLE
[CFM-1244] Remove unpublish button from groups/projects

### DIFF
--- a/project/profiles/capacity4more/behat/features/bootstrap/FeatureContext/Node.php
+++ b/project/profiles/capacity4more/behat/features/bootstrap/FeatureContext/Node.php
@@ -51,6 +51,29 @@ trait Node {
   }
 
   /**
+   * @When /^I start editing "([^"]*)" node$/
+   */
+  public function iStartEditingNode($title) {
+    $q = new \entityFieldQuery();
+    $q->entityCondition('entity_type', 'node');
+    $q->propertyCondition('title', $title);
+    $q->range(0, 1);
+
+    $result = $q->execute();
+
+    if (empty($result['node'])) {
+      $params = array(
+        '@title' => $title,
+      );
+      throw new \Exception(format_string("Node with title '@title' not found.", $params));
+    }
+
+    $nid = key($result['node']);
+
+    return new Given("I go to \"node/$nid/edit\"");
+  }
+
+  /**
    * @Then /^I should not be allowed to create a "([^"]*)"$/
    */
   public function iShouldNotBeAllowedToCreateA($type) {

--- a/project/profiles/capacity4more/behat/features/content_form.feature
+++ b/project/profiles/capacity4more/behat/features/content_form.feature
@@ -12,3 +12,9 @@ Feature: Content Forms
     Given I am logged in as user "alfrednobel"
      When I visit the page "node/add/event" in the group "Nobel Prize"
      Then I should see "Save as draft" in the "#edit-draft" element
+
+  @api
+  Scenario: Check unpublish button on node edit forms as an authenticated user
+    Given I am logged in as user "alfrednobel"
+    When  I start editing "Nobel Prize" node
+    Then  I should not see "Unpublish" in the "#edit-actions" element

--- a/project/profiles/capacity4more/behat/features/group_discussions.feature
+++ b/project/profiles/capacity4more/behat/features/group_discussions.feature
@@ -52,3 +52,10 @@ Feature: Group Discussions
     And   I start editing "discussion" "Some new discussion3" in group "Tennis Group"
     Then  I should see "Edit discussion"
     And   I should see "Some new discussion3"
+
+  @javascript
+  Scenario: Check unpublish button on node edit forms as an authenticated user
+    Given I am logged in as user "alfrednobel"
+    And   a discussion "Edit this discussion" in group "NobelPrize" is created
+    When  I start editing "discussion" "Edit this discussion" in group "Nobel Prize"
+    Then  I should see "Unpublish" in the "#edit-draft" element

--- a/project/profiles/capacity4more/modules/c4m/content/c4m_content/c4m_content.module
+++ b/project/profiles/capacity4more/modules/c4m/content/c4m_content/c4m_content.module
@@ -38,9 +38,11 @@ function c4m_content_form_node_form_alter(&$form, &$form_state, $form_id) {
     );
   }
 
+  $is_unpublish = $form['actions']['draft']['#value'] == t('Unpublish');
+  $is_og_group = in_array($form['type']['#value'], array('group', 'project'));
   // Removes Unpublish button from forms.
-  if ($form['actions']['draft']['#value'] == t('Unpublish')) {
-    unset($form['actions']['draft']);
+  if ($is_unpublish && $is_og_group) {
+    $form['actions']['draft']['#access'] = FALSE;
   }
 }
 


### PR DESCRIPTION
Issue: https://issuetracker.amplexor.com/jira/browse/CFM-1244

Previous PR: https://github.com/capacity4dev/capacity4more/pull/1086

Screenshots:
Before, when editing a discussion, the unpublish button was gone:
![discussions-before](https://cloud.githubusercontent.com/assets/877002/17886125/b3561f60-6920-11e6-8a2f-d9ce04c3d757.png)
After, when editing a discussion the unpublish button is there:
![discussions-after](https://cloud.githubusercontent.com/assets/877002/17886132/c3a8f586-6920-11e6-859f-2ba3299a9a11.png)
When editing a group or project, the unpublish button is still gone:
![groups-actions](https://cloud.githubusercontent.com/assets/877002/17886154/d283e7be-6920-11e6-85e7-d9a03cc626b6.png)

