### PR TITLE
[CFM-1148] Fixes for group view modes

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/content/c4m_content_group/c4m_content_group.module
+++ b/project/profiles/capacity4more/modules/c4m/content/c4m_content_group/c4m_content_group.module
@@ -711,7 +711,7 @@ function c4m_content_group_node_view($node, $view_mode, $langcode) {
     '#type' => 'item',
     '#title' => t('Group administrators'),
     '#title_display' => 'above',
-    '#markup' => implode(",", $links),
+    '#suffix' => implode(",", $links),
   );
 
   $node->content['#pre_render'][] = 'c4m_content_group_theme_topics_and_regions';


### PR DESCRIPTION
Moves markup of the group admins to a theme suffix to ensure is added after the title.

Issue: https://issuetracker.amplexor.com/jira/browse/CFM-1148

Screenshots:
### Both issues fixed:
![group-view-modes](https://cloud.githubusercontent.com/assets/877002/18476414/335f8c28-79ca-11e6-9c2d-deb26ac77cc0.png)
### Desktop
![groups-desktop](https://cloud.githubusercontent.com/assets/877002/18476423/3e461bde-79ca-11e6-9d7b-dd5aabd3ecc2.png)
### Tablet
![groups-tablet](https://cloud.githubusercontent.com/assets/877002/18476425/3e4e5c54-79ca-11e6-80ff-4ecf746b5b44.png)
### Mobile
![groups-mobile](https://cloud.githubusercontent.com/assets/877002/18476424/3e476318-79ca-11e6-9eb9-5e55a21ce0e9.png)
