### PR TITLE
[BUGFIX] Group notifications toggle link should not appear for non members of a group.

### DIFF
--- a/project/profiles/capacity4more/behat/features/group_dashboard.feature
+++ b/project/profiles/capacity4more/behat/features/group_dashboard.feature
@@ -63,6 +63,13 @@ Feature: Group dashboard
     Then  I should not see the link "Invite a member"
 
   @api
+  Scenario: Check notifications toggle link is not available for a non-member of a group.
+    Given I am logged in as user "president"
+    When  I visit the dashboard of group "Movie Popcorn Corner"
+    Then  I should not see the link "Enable notifications"
+    And   I should not see the link "Disable notifications"
+
+  @api
   Scenario: Check Invite a member link is available for an administrator of a private group.
     Given I am logged in as user "alfrednobel"
     When  I visit the dashboard of group "Tennis Group"

--- a/project/profiles/capacity4more/modules/c4m/user/c4m_user_og/c4m_user_og.module
+++ b/project/profiles/capacity4more/modules/c4m/user/c4m_user_og/c4m_user_og.module
@@ -812,6 +812,10 @@ function c4m_user_og_c4m_leave_group_cta($group) {
  * Sets the CTA to follow or unfollow group notifications.
  */
 function c4m_user_og_follow_group_cta($group) {
+  if (!og_is_member('node', $group->nid)) {
+    return FALSE;
+  }
+
   $item = array(
     '#theme' => 'c4m_group_text_cta',
     '#icon' => 'fa-bell-o',


### PR DESCRIPTION
Following the comment @soniCaH left on https://issuetracker.amplexor.com/jira/browse/CFM-1348
@anvmn found this bug.
![selection_301](https://cloud.githubusercontent.com/assets/5985683/18717241/01ca4fae-8028-11e6-998b-92d965028bd9.png)
