### PR TITLE
[CFM-546-fix] Make sure owner is included when selecting group admins

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/og/c4m_og/c4m_og.module
+++ b/project/profiles/capacity4more/modules/c4m/og/c4m_og/c4m_og.module
@@ -1110,7 +1110,7 @@ function c4m_og_get_group_admins_ids($gid, $verify_owner_added = FALSE, $filter_
  *   An array of all group admins ids.
  */
 function c4m_og_get_group_admins_and_owner_ids_for_notification($gid) {
-  $admins_ids = c4m_og_get_group_admins_ids($gid, FALSE, TRUE);
+  $admins_ids = c4m_og_get_group_admins_ids($gid, TRUE, TRUE);
   $group = node_load($gid);
   $admins = user_load_multiple($admins_ids);
 


### PR DESCRIPTION
https://issuetracker.amplexor.com/jira/browse/CFM-546

The problem was that owner was not included in groups admins list.