### PR TITLE
CFM-631: Fixes for groups export

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/admin/c4m_admin_groups/c4m_admin_groups.views_default.inc
+++ b/project/profiles/capacity4more/modules/c4m/admin/c4m_admin_groups/c4m_admin_groups.views_default.inc
@@ -369,13 +369,6 @@ function c4m_admin_groups_views_default_views() {
   $handler->display->display_options['fields']['group_metrics_9']['label'] = 'Contributors';
   $handler->display->display_options['fields']['group_metrics_9']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['group_metrics_9']['c4m_admin_groups_group_metric'] = 'group::contributors';
-  /* Field: Content: Group metrics */
-  $handler->display->display_options['fields']['group_metrics_11']['id'] = 'group_metrics_11';
-  $handler->display->display_options['fields']['group_metrics_11']['table'] = 'node';
-  $handler->display->display_options['fields']['group_metrics_11']['field'] = 'group_metrics';
-  $handler->display->display_options['fields']['group_metrics_11']['label'] = 'Contributors/Active members (in %)';
-  $handler->display->display_options['fields']['group_metrics_11']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['group_metrics_11']['c4m_admin_groups_group_metric'] = 'group::contributors_vs_pending_members';
   /* Field: Flags: Flag counter */
   $handler->display->display_options['fields']['count']['id'] = 'count';
   $handler->display->display_options['fields']['count']['table'] = 'flag_counts';

--- a/project/profiles/capacity4more/modules/c4m/helper/c4m_helper_entity/c4m_helper_entity.module
+++ b/project/profiles/capacity4more/modules/c4m/helper/c4m_helper_entity/c4m_helper_entity.module
@@ -83,6 +83,7 @@ function c4m_helper_entity_get_number_of_entities(array $variables) {
     'bundles' => array(),
     'state' => NULL,
     'og_id' => NULL,
+    'og_state' => OG_STATE_ACTIVE,
     'uid' => NULL,
     'topic' => NULL,
     'c4m_status' => NULL,
@@ -95,6 +96,7 @@ function c4m_helper_entity_get_number_of_entities(array $variables) {
   $bundles = $variables['bundles'];
   $state = $variables['state'];
   $og_id = $variables['og_id'];
+  $og_state = $variables['og_state'];
   $uid = $variables['uid'];
   $topic = $variables['topic'];
   $c4m_status = $variables['c4m_status'];
@@ -142,6 +144,7 @@ function c4m_helper_entity_get_number_of_entities(array $variables) {
       switch ($entity_type) {
         case 'user':
           $query->join('og_membership', 'og', "u.uid = og.etid AND og.entity_type = 'user'");
+          $query->condition('og.state', $og_state);
           break;
 
         case 'node':

--- a/project/profiles/capacity4more/modules/c4m/user/c4m_user_og/c4m_user_og.module
+++ b/project/profiles/capacity4more/modules/c4m/user/c4m_user_og/c4m_user_og.module
@@ -401,30 +401,6 @@ function c4m_user_og_get_number_of_active_members($og_id = NULL) {
 }
 
 /**
- * Returns the amount of contributors vs active members in a group.
- *
- * @param int $og_id
- *   The Organic Group ID to limit the query for.
- *
- * @return int
- *   The amount of contributors vs active members of a group.
- */
-function c4m_user_og_get_number_of_contributors_vs_members($og_id) {
-  $contributors = c4m_user_og_get_number_of_contributors($og_id);
-  $active_members = c4m_user_og_get_number_of_active_members($og_id);
-
-  if (is_numeric($contributors) && (is_numeric(
-        $active_members
-      ) && $active_members > 0)
-  ) {
-    $calculation = $contributors / $active_members * 100;
-    return empty($calculation) ? 0 : $calculation;
-  }
-
-  return 0;
-}
-
-/**
  * Implements hook_c4m_content_statistics_info().
  */
 function c4m_user_og_c4m_content_statistics_info() {
@@ -482,12 +458,6 @@ function c4m_user_og_c4m_helper_entity_metrics_info() {
       'context' => 'group',
       'callback' => 'c4m_user_og_get_number_of_contributors',
       'weight' => 9,
-    ),
-    'c4m_og_contributors_vs_pending_members' => array(
-      'type' => 'contributors_vs_pending_members',
-      'context' => 'group',
-      'callback' => 'c4m_user_og_get_number_of_contributors_vs_members',
-      'weight' => 13,
     ),
     'c4m_og_pending_members' => array(
       'type' => 'pending_members',


### PR DESCRIPTION
- Add the OG (active) state to the metrics query.
- Remove the members vs contributors statistic.