### PR TITLE
CAPFDEV-1227: Increase the maxlength of c4d_document widget.

### DIFF
--- a/project/profiles/capacity4more/modules/c4m/widgets/c4m_document_widget/c4m_document_widget.module
+++ b/project/profiles/capacity4more/modules/c4m/widgets/c4m_document_widget/c4m_document_widget.module
@@ -87,6 +87,11 @@ function c4m_document_widget_field_widget_form(&$form, &$form_state, $field, $in
   $element['#prefix'] = '<div class="ng-hide">';
   $element['#suffix'] = '</div>';
 
+  // Default is 1024, which is too little for some groups.
+  // CAPFDEV-1227 reports 2283 for instance.
+  // We keep a limit however for security reasons.
+  $element['#maxlength'] = 2500;
+
   // Add the angular directive.
   // Get the existing field value.
   $default_value = $element['#default_value'];


### PR DESCRIPTION
Increase the maxlength of c4d_document widget (entity reference) from 1024 (default) to 2500.