### PR TITLE
EASME-53: Applied patch that fixes error from OG Vocab widget

### DIFF
--- a/config/make/og.make
+++ b/config/make/og.make
@@ -22,6 +22,7 @@ projects[og_vocab][subdir] = "contrib"
 projects[og_vocab][version] = "1.2"
 projects[og_vocab][patch][] = https://www.drupal.org/files/issues/og_vocab-fix_strict_warning.patch
 projects[og_vocab][patch][] = https://www.drupal.org/files/issues/2399883-og_vocab-menuitem-7.patch
+projects[og_vocab][patch][] = https://www.drupal.org/files/issues/og_vocab-unset-theme-2379169-1.patch
 
 projects[pluggable_node_access][subdir] = "contrib"
 projects[pluggable_node_access][version] = "1.x-dev"


### PR DESCRIPTION
Cherrypick from https://github.com/easme-web/capacity4more/pull/24.