### PR TITLE
Pinpoint the solr version drush needs to download.

### DIFF
--- a/ci/bin/install_solr.sh
+++ b/ci/bin/install_solr.sh
@@ -22,6 +22,6 @@ SCRIPT_CONFIG="$TRAVIS_BUILD_DIR/search_api_solr/solr-conf/5.x"
 CORE_NAME="$1"
 
 cd $TRAVIS_BUILD_DIR
-drush dl search_api_solr
+drush dl search_api_solr-7.x-1.12
 curl -sSL $SCRIPT_URL | SOLR_CORE="$CORE_NAME" SOLR_CONFS="$SCRIPT_CONFIG" bash
 rm -R $TRAVIS_BUILD_DIR/search_api_solr


### PR DESCRIPTION
Default version was switched to Drupal 8 version, since we are not in a Drupal environment when we download the module. Therefore the config folder in the installation instructions was changed and caused errors.